### PR TITLE
Release/2.5.0

### DIFF
--- a/CountriesArray.php
+++ b/CountriesArray.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2020 PayGate (Pty) Ltd
+ * Copyright (c) 2022 PayGate (Pty) Ltd
  *
  * Author: App Inlet (Pty) Ltd
  *

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PayWeb_Gravity_Forms
-## PayGate Gravity Forms plugin v2.2.11 for Gravity Forms v2.4.18, WordPress v5.4.2
+## PayGate Gravity Forms plugin v2.5.0 for Gravity Forms v2.5.16.1, WordPress v5.9
 
 This is the PayGate PayWeb3 plugin for Gravity Forms. Please feel free to contact the PayGate support team at support@paygate.co.za should you require any assistance.
 
 ## Installation
 [![How To Setup PayGate PayWeb for Gravity Forms](https://appinlet.com/wp-content/uploads/2021/01/How-To-Setup-PayGate-PayWeb-for-Gravity-Forms.jpg)](https://www.youtube.com/watch?v=r5nx1EfyOlo "How To Setup PayGate PayWeb for Gravity Forms")
 
-Please navigate to the [releases page](https://github.com/PayGate/PayWeb_Gravity_Forms/releases), download the latest release (v2.2.11) and unzip. You will then be able to follow the integration guide PDF which is included in the zip.
+Please navigate to the [releases page](https://github.com/PayGate/PayWeb_Gravity_Forms/releases), download the latest release (v2.5.0) and unzip. You will then be able to follow the integration guide PDF which is included in the zip.
 
 ## Collaboration
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 2.5.0 - February 01, 2022 =
+* Tested with Wordpress 5.9 and Gravity Forms 2.5.16.1.
+* Use correct plugin version.
+* Improve IPN reliability.
+
 = 2.2.11 - June 23, 2020 =
 * Fix notify in redirect link.
 * Updated version and dates.

--- a/paygate-tools.php
+++ b/paygate-tools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2020 PayGate (Pty) Ltd
+ * Copyright (c) 2022 PayGate (Pty) Ltd
  *
  * Author: App Inlet (Pty) Ltd
  *

--- a/paygate.php
+++ b/paygate.php
@@ -3,8 +3,8 @@
  * Plugin Name: Gravity Forms PayGate Add-On
  * Plugin URI: https://github.com/PayGate/PayWeb_Gravity_Forms
  * Description: Integrates Gravity Forms with PayGate, a South African payment gateway.
- * Version: 2.4.18
- * Tested: 5.4.2
+ * Version: 2.5.0
+ * Tested: 5.9
  * Author: PayGate (Pty) Ltd
  * Author URI: https://www.paygate.co.za/
  * Developer: App Inlet (Pty) Ltd
@@ -12,7 +12,7 @@
  * Text Domain: gravityformspaygate
  * Domain Path: /languages
  *
- * Copyright: © 2020 PayGate (Pty) Ltd.
+ * Copyright: © 2022 PayGate (Pty) Ltd.
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -49,7 +49,7 @@ function paygate_init()
             'homepage'           => 'https://github.com/PayGate/PayWeb_Gravity_Forms',
             'sslverify'          => true,
             'requires'           => '4.0',
-            'tested'             => '5.3.0',
+            'tested'             => '5.9.0',
             'readme'             => 'README.md',
             'access_token'       => '',
         );

--- a/paygate_gf_class.php
+++ b/paygate_gf_class.php
@@ -881,8 +881,6 @@ $html = ob_get_clean();
             $payGate  = new PayGate();
             $instance = self::get_instance();
 
-            $instance->log_debug( "POST: " . print_r( $_POST, true ) );
-
             $errors       = false;
             $paygate_data = array();
 

--- a/paygate_gf_class.php
+++ b/paygate_gf_class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2020 PayGate (Pty) Ltd
+ * Copyright (c) 2022 PayGate (Pty) Ltd
  *
  * Author: App Inlet (Pty) Ltd
  *
@@ -54,7 +54,6 @@ class PayGateGF extends GFPaymentAddOn
         parent::init_frontend();
 
         add_filter( 'gform_disable_post_creation', array( $this, 'delay_post' ), 10, 3 );
-        add_filter( 'gform_disable_notification', array( $this, 'delay_notification' ), 10, 4 );
 
         add_action( 'gform_post_payment_action', function ( $entry, $action ) {
             $form = GFAPI::get_form( $entry['form_id'] );
@@ -207,7 +206,7 @@ class PayGateGF extends GFPaymentAddOn
         $fields = array(
             array(
                 'name'  => 'logo',
-                'label' => __( '<img src=' . '"https://secure.paygate.co.za/payweb3/images/pglogo_transparent.png"' . ' style=' . '"margin:-10% 50px -8% -20px;"' . '></br></br>', 'gravityformspaygate' ),
+                'label' =>  __( 'PayGate PayWeb3', 'gravityformspaygate' ),
                 'type'  => 'custom' ),
         );
 
@@ -485,7 +484,7 @@ $html = ob_get_clean();
             'NOTIFY_URL'       => $notify_url,
             'USER1'            => $entry['created_by'],
             'USER2'            => get_bloginfo( 'admin_email' ),
-            'USER3'            => 'gravityforms-v2.2.8',
+            'USER3'            => 'gravityforms-v2.5.0',
         );
         $fields['CHECKSUM'] = md5( implode( '', $fields ) . $merchant_key );
         $payGate            = new PayGate();
@@ -867,13 +866,22 @@ $html = ob_get_clean();
     // Notification
     public static function notify_handler()
     {
-
         if ( isset( $_GET["page"] ) ) {
             // Notify paygate that the request was successful
-            echo "OK";
+            echo "OK   ";
+
+            $payRequestId = $_POST['PAY_REQUEST_ID'];
+            $transient = get_transient($payRequestId);
+            if (!$transient) {
+                set_transient($payRequestId, '1', 10);
+            } else {
+                return;
+            }
 
             $payGate  = new PayGate();
             $instance = self::get_instance();
+
+            $instance->log_debug( "POST: " . print_r( $_POST, true ) );
 
             $errors       = false;
             $paygate_data = array();


### PR DESCRIPTION
= 2.5.0 - February 01, 2022 =
* Tested with Wordpress 5.9 and Gravity Forms 2.5.16.1.
* Use correct plugin version.
* Improve IPN reliability.