### PR TITLE
Fixed an issue that prevents other active feeds from running

### DIFF
--- a/src/PayGateGF.php
+++ b/src/PayGateGF.php
@@ -942,7 +942,6 @@ class PayGateGF extends \GFPaymentAddOn
         unset($fields['CHECKSUM']);
         $checksum = md5(implode('', $fields) . $merchant_key);
         print $payGate->getPaygatePostForm($fields['PAY_REQUEST_ID'], $checksum);
-        exit;
     }
 
     public function get_product_query_string($submission_data, $entry_id)


### PR DESCRIPTION
The `PayWeb_Gravity_Forms` plugin prevents other active feeds from running. The PR should fix the issue.